### PR TITLE
Optional "difference" flag for aggregate endpoint

### DIFF
--- a/packages/energy-api-influxdb/src/reads/dto/aggregate-filter.dto.ts
+++ b/packages/energy-api-influxdb/src/reads/dto/aggregate-filter.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsString, Matches } from 'class-validator';
+import { Transform } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
 
 import { Aggregate } from '../aggregate.enum';
 import { RangeFilterDTO } from './range-filter.dto';
@@ -18,4 +25,14 @@ export class AggregateFilterDTO extends RangeFilterDTO {
   @IsEnum(Aggregate)
   @ApiProperty({ enum: Aggregate, enumName: 'Aggregate' })
   aggregate: Aggregate;
+
+  @IsBoolean()
+  @Transform((value) => value === 'true')
+  @IsOptional()
+  @ApiProperty({
+    type: Boolean,
+    description:
+      'When "true" it will calculate the difference between reads before applying aggregation functions',
+  })
+  difference?: boolean;
 }

--- a/packages/energy-api-influxdb/src/reads/reads.service.ts
+++ b/packages/energy-api-influxdb/src/reads/reads.service.ts
@@ -73,7 +73,7 @@ export class ReadsService implements OnModuleInit {
       from(bucket: "${this.bucket}")
       |> range(start: ${filter.start}, stop: ${filter.end})
       |> filter(fn: (r) => r.meter == "${meterId}" and r._field == "read")
-      |> difference()
+      ${filter.difference ? '|> difference()' : ''}
       |> window(every: ${filter.window})
       |> ${filter.aggregate}()
       `;

--- a/packages/energy-api-influxdb/test/app.e2e-spec.ts
+++ b/packages/energy-api-influxdb/test/app.e2e-spec.ts
@@ -96,6 +96,26 @@ describe('ReadsController (e2e)', () => {
       });
   });
 
+  it('should return aggregated monthly sum without calculating difference', async () => {
+    await request(app)
+      .get('/meter-reads/M1/aggregate')
+      .query({
+        start: new Date('2020-01-01').toISOString(),
+        end: new Date('2020-03-01').toISOString(),
+        window: '1mo',
+        aggregate: Aggregate.Sum,
+        difference: false,
+      })
+      .expect(200)
+      .expect((res) => {
+        const reads = res.body as ReadDTO[];
+
+        expect(reads).to.have.length(2);
+        expect(reads[0].value).to.equal((1700 + 1500) * 10 ** 3);
+        expect(reads[1].value).to.equal((2000 + 2500) * 10 ** 3);
+      });
+  });
+
   it('should return aggregated monthly sum', async () => {
     await request(app)
       .get('/meter-reads/M1/aggregate')
@@ -104,6 +124,7 @@ describe('ReadsController (e2e)', () => {
         end: new Date('2020-03-01').toISOString(),
         window: '1mo',
         aggregate: Aggregate.Sum,
+        difference: true,
       })
       .expect(200)
       .expect((res) => {
@@ -123,6 +144,7 @@ describe('ReadsController (e2e)', () => {
         end: new Date('2020-03-01').toISOString(),
         window: '1y',
         aggregate: Aggregate.Sum,
+        difference: true,
       })
       .expect(200)
       .expect((res) => {

--- a/specs/schema.yaml
+++ b/specs/schema.yaml
@@ -221,6 +221,12 @@ paths:
           in: "query"
           schema:
             $ref: "#/components/schemas/Aggregate"
+        - name: "difference"
+          required: true
+          in: "query"
+          description: "When \"true\" it will calculate the difference between reads before applying aggregation functions"
+          schema:
+            type: "boolean"
       responses:
         200:
           description: "Returns aggregated time-series of difference between subsequent meter reads"


### PR DESCRIPTION
This PR implements the optional "difference" flag for the aggregate endpoint, this enables energy api to apply aggregate functions for reads that are already "relative" 

Smart meter reads can be delivered in 2 different formats:

- "absolute" meter value, increasing number like 100, 110, 120 etc
- "relative" metered over time like 0,10,10,0,20 etc