### PR TITLE
fix(energy-api-influxdb): make ReadDTO properly validated, make it accept negative values

### DIFF
--- a/packages/energy-api-influxdb/src/reads/dto/measurement.dto.ts
+++ b/packages/energy-api-influxdb/src/reads/dto/measurement.dto.ts
@@ -1,10 +1,12 @@
 import { Unit } from '../unit.enum';
 import { IsEnum, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { ReadDTO } from './';
 
 export class MeasurementDTO {
   @ValidateNested()
+  @Type(() => ReadDTO)
   @ApiProperty({ type: () => [ReadDTO] })
   reads: ReadDTO[];
 

--- a/packages/energy-api-influxdb/src/reads/dto/read.dto.ts
+++ b/packages/energy-api-influxdb/src/reads/dto/read.dto.ts
@@ -1,4 +1,4 @@
-import { IsDate, IsNumber, IsPositive } from 'class-validator';
+import { IsDate, IsNumber } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -14,7 +14,6 @@ export class ReadDTO {
   timestamp: Date;
 
   @IsNumber()
-  @IsPositive()
   @ApiProperty({
     type: 'integer',
     example: 10000000,


### PR DESCRIPTION
Negative values are required for one of integrations

ReadDTO was not validated at all, so it accepted invalid Dates